### PR TITLE
We recommend using symbolic names like hw:Live but when subdevices are u...

### DIFF
--- a/drivers/alsa/alsa_driver.c
+++ b/drivers/alsa/alsa_driver.c
@@ -96,30 +96,47 @@ alsa_driver_check_capabilities (alsa_driver_t *driver)
 	return 0;
 }
 
+static char*
+get_control_device_name(const char * device_name)
+{
+    char * ctl_name;
+    const char * comma;
+
+    /* the user wants a hw or plughw device, the ctl name
+     * should be hw:x where x is the card identification.
+     * We skip the subdevice suffix that starts with comma */
+
+    if (strncasecmp(device_name, "plughw:", 7) == 0) {
+        /* skip the "plug" prefix" */
+        device_name += 4;
+    }
+
+    comma = strchr(device_name, ',');
+    if (comma == NULL) {
+        ctl_name = strdup(device_name);
+        if (ctl_name == NULL) {
+            jack_error("strdup(\"%s\") failed.", device_name);
+        }
+    } else {
+        ctl_name = strndup(device_name, comma - device_name);
+        if (ctl_name == NULL) {
+            jack_error("strndup(\"%s\", %u) failed.", device_name, (unsigned int)(comma - device_name));
+        }
+    }
+
+    return ctl_name;
+}
+
 static int
 alsa_driver_check_card_type (alsa_driver_t *driver)
 {
 	int err;
 	snd_ctl_card_info_t *card_info;
 	char * ctl_name;
-	regex_t expression;
 
 	snd_ctl_card_info_alloca (&card_info);
 
-	regcomp(&expression,"(plug)?hw:[0-9](,[0-9])?",REG_ICASE|REG_EXTENDED);
-	
-       	if (!regexec(&expression,driver->alsa_name_playback,0,NULL,0)) {
-		/* the user wants a hw or plughw device, the ctl name
-		 * should be hw:x where x is the card number */
-	
-		char tmp[5];
-		strncpy(tmp,strstr(driver->alsa_name_playback,"hw"),4);
-		tmp[4]='\0';
-		jack_info("control device %s",tmp);
-		ctl_name = strdup(tmp);
-	} else {
-		ctl_name = strdup(driver->alsa_name_playback);
-	}
+	ctl_name = get_control_device_name(driver->alsa_name_playback);
 
 	// XXX: I don't know the "right" way to do this. Which to use
 	// driver->alsa_name_playback or driver->alsa_name_capture.
@@ -134,7 +151,6 @@ alsa_driver_check_card_type (alsa_driver_t *driver)
 
 	driver->alsa_driver = strdup(snd_ctl_card_info_get_driver (card_info));
 
-	regfree(&expression);
 	free(ctl_name);
 
 	return alsa_driver_check_capabilities (driver);


### PR DESCRIPTION
The control device reservation was failing when symbolic device name was used along with subdevices. See the commit message for more info.
