### PR TITLE
Add  memset to clear buffer to unparse uuid into.

### DIFF
--- a/libjack/metadata.c
+++ b/libjack/metadata.c
@@ -302,6 +302,7 @@ jack_get_properties (jack_uuid_t subject,
         desc->properties = NULL;
         desc->property_cnt = 0;
 
+        memset(ustr, 0, JACK_UUID_STRING_SIZE);
         jack_uuid_unparse (subject, ustr);
 
         if (jack_property_init (NULL)) {
@@ -595,6 +596,7 @@ jack_remove_properties (jack_client_t* client, jack_uuid_t subject)
         int retval = 0;
         uint32_t cnt = 0;
 
+        memset(ustr, 0, JACK_UUID_STRING_SIZE);
         jack_uuid_unparse (subject, ustr);
 
         if (jack_property_init (NULL)) {


### PR DESCRIPTION
- jack_remove_properties and jack_get_properties both search the metadata database for a matching UUID string.
- However, they both fail at finding any matching UUIDs ever.
- The UUID string in the database are correctly created on a previously cleared buffer (e.g. memset to 0).
- The temporaty UUID string in the search routines however are not created on a cleared buffer, the end of the buffer thus may contain anything.
- As in the matching routine the complete UUID strings are compared (with size JACK_UUID_STRING_SIZE), there will never be a matching pair, even if their valid part do match.

Fixes Issue #8
