### PR TITLE
Stop libjack object files being compiled and duplicated in libjackserver...

### DIFF
--- a/jackd/Makefile.am
+++ b/jackd/Makefile.am
@@ -1,3 +1,5 @@
+NULL=
+
 MAINTAINERCLEANFILES = Makefile.in jackd.1 jack_md5.h 
 
 if USE_CAPABILITIES
@@ -24,7 +26,7 @@ bin_PROGRAMS = jackd $(CAP_PROGS)
 AM_CFLAGS = $(JACK_CFLAGS) -DJACK_LOCATION=\"$(bindir)\"
 
 jackd_SOURCES = jackd.c
-jackd_LDADD = libjackserver.la $(CAP_LIBS) @OS_LDFLAGS@
+jackd_LDADD = libjackserver.la $(CAP_LIBS) @OS_LDFLAGS@ $(top_builddir)/libjack/libjack.la
 
 noinst_HEADERS = jack_md5.h md5.h md5_loc.h \
 		 clientengine.h transengine.h
@@ -44,18 +46,14 @@ lib_LTLIBRARIES	= libjackserver.la
 
 libjackserver_la_CFLAGS = $(AM_CFLAGS)
 
-libjackserver_la_SOURCES = engine.c clientengine.c transengine.c controlapi.c \
-	../libjack/systemtest.c ../libjack/sanitycheck.c \
-	../libjack/client.c ../libjack/driver.c ../libjack/intclient.c \
-        ../libjack/messagebuffer.c ../libjack/pool.c ../libjack/port.c \
-        ../libjack/midiport.c ../libjack/ringbuffer.c ../libjack/shm.c \
-        ../libjack/thread.c ../libjack/time.c  ../libjack/transclient.c \
-        ../libjack/unlock.c ../libjack/uuid.c ../libjack/metadata.c
-libjackserver_la_LIBADD  = simd.lo -ldb @OS_LDFLAGS@ 
-libjackserver_la_LDFLAGS  = -export-dynamic -version-info @JACK_SO_VERSION@
+libjackserver_la_SOURCES = engine.c \
+	clientengine.c \
+	transengine.c \
+	controlapi.c \
+	$(NULL)
 
-simd.lo: $(srcdir)/../libjack/simd.c
-	$(LIBTOOL) --mode=compile $(CC) -I$(top_builddir) $(JACK_CORE_CFLAGS) $(SIMD_CFLAGS) -c -o simd.lo $(srcdir)/../libjack/simd.c
+libjackserver_la_LIBADD  = -ldb @OS_LDFLAGS@ $(top_builddir)/libjack/libjack.la
+libjackserver_la_LDFLAGS  = -export-dynamic -version-info @JACK_SO_VERSION@
 
 man_MANS = jackd.1 jackstart.1
 EXTRA_DIST = $(man_MANS)

--- a/libjack/Makefile.am
+++ b/libjack/Makefile.am
@@ -1,3 +1,5 @@
+NULL=
+
 MAINTAINERCLEANFILES    = Makefile.in
 
 if USE_POSIX_SHM
@@ -10,20 +12,24 @@ install-exec-hook:
 endif
 
 SOURCE_FILES = \
-	     client.c \
-	     intclient.c \
-	     messagebuffer.c \
-	     pool.c \
-	     port.c \
-	     metadata.c \
-             midiport.c \
-	     ringbuffer.c \
-	     shm.c \
-	     thread.c \
-             time.c \
-	     transclient.c \
-	     unlock.c \
-	     uuid.c
+	client.c \
+	driver.c \
+	intclient.c \
+	messagebuffer.c \
+	pool.c \
+	port.c \
+	metadata.c \
+	midiport.c \
+	ringbuffer.c \
+	sanitycheck.c \
+	shm.c \
+	systemtest.c \
+	thread.c \
+	time.c \
+	transclient.c \
+	unlock.c \
+	uuid.c \
+	$(NULL)
 
 simd.lo: $(srcdir)/simd.c
 	$(LIBTOOL) --mode=compile $(CC) -I$(top_builddir) $(JACK_CORE_CFLAGS) $(SIMD_CFLAGS) -c -o simd.lo $(srcdir)/simd.c


### PR DESCRIPTION
This resolves an issue where multiple versions of the symbols are resolved due to them living in the two DSOs.
