### PR TITLE
support [unescaped] double-quotes in jackdrc

### DIFF
--- a/libjack/client.c
+++ b/libjack/client.c
@@ -932,17 +932,33 @@ _start_server (const char *server_name)
 			}
 		}
 
-		result = strcspn(arguments+pos, " ");
-		if (result == 0) {
+		/* skip whitespace */
+		while (pos < strlen(arguments) && arguments[pos] && arguments[pos] == ' ') {
+			++pos;
+		}
+
+		if (pos >= strlen(arguments)) {
 			break;
 		}
-		argv[i] = (char*)malloc(result+1);
 
-		strncpy(argv[i], arguments+pos, result);
+		if (arguments[pos] == '\"') {
+			++pos;
+			result = strcspn(arguments + pos, "\"");
+		} else {
+			result = strcspn(arguments + pos, " ");
+		}
+
+		if (0 == result) {
+			break;
+		}
+
+		argv[i] = (char*)malloc(result + 1);
+		strncpy(argv[i], arguments + pos, result);
 		argv[i][result] = '\0';
-
-		pos += result+1;
-		++i;
+		pos += result + 1;
+		if (++i > 253) {
+			break;
+		}
 	}
 	argv[i] = 0;
 


### PR DESCRIPTION
allow autostart of jackd on OSX where device-names can
contain spaces.