### PR TITLE
[alsa_midi] fix hotplug device (de)enumeration

### DIFF
--- a/drivers/alsa_midi/a2j.h
+++ b/drivers/alsa_midi/a2j.h
@@ -88,7 +88,6 @@ typedef struct alsa_midi_driver
     bool running;
     bool finishing;
 
-    jack_ringbuffer_t* port_add; // snd_seq_addr_t
     jack_ringbuffer_t* port_del; // struct a2j_port*
     jack_ringbuffer_t* outbound_events; // struct a2j_delivery_event
     jack_nframes_t cycle_start;

--- a/drivers/alsa_midi/port_thread.h
+++ b/drivers/alsa_midi/port_thread.h
@@ -23,8 +23,9 @@
 #define PORT_THREAD_H__1C6B5065_5556_4AC6_AA9F_44C32A9648C6__INCLUDED
 
 void a2j_update_port (alsa_midi_driver_t* driver, snd_seq_addr_t addr, const snd_seq_port_info_t* info);
-void a2j_update_ports (alsa_midi_driver_t* driver);
-void a2j_free_ports (jack_ringbuffer_t * ports);
+void a2j_update_ports (alsa_midi_driver_t* driver, snd_seq_addr_t addr);
+void a2j_new_ports (alsa_midi_driver_t* driver, snd_seq_addr_t addr);
+void a2j_free_ports (alsa_midi_driver_t* driver);
 struct a2j_port * a2j_find_port_by_addr (struct a2j_stream * stream_ptr, snd_seq_addr_t addr);
 struct a2j_port * a2j_find_port_by_jack_port_name (struct a2j_stream * stream_ptr, const char * jack_port);
 


### PR DESCRIPTION
Issues:
- With a running JACK with enabled alsa_midi driver (-X alsa_midi), plugging in
	a new MIDI device has no effect, e.g. no corresponding JACK ports are spawned
- With a running JACK with enabled alsa_midi driver (-X alsa_midi), deplugging
	a MIDI device has no effect, e.g. the corresponding JACK ports stay around

Result:
- JACK only creates JACK ports of ALSA MIDI clients/ports found at startup
- JACK has to be restarted for any ALSA MIDI device (de)enumeration to take
	place

Problem:
- There are some functions defined which actually should accomplish this in the
	alsa_midi driver code (e.g. 'a2j_update_ports' and 'a2j_free_ports'), but they
	are not called from any other function ;-)

Solution:
- Discriminate properly between ALSA PORT_START and PORT_CHANGE events
	- 'a2j_new_ports' function has been added which recycles some code from
		'alsa_input_thread'
- Actually call the already existing hot(de)plugging infrastructure
	- 'a2j_update_ports' and 'a2j_new_ports' get called from the
		'alsa_input_thread'
	- 'a2j_free_ports' gets called from 'alsa_output_thread'
	- 'alsa_out_thread' is woken up by 'a2j_jack_process_internal'
- Cleanup code that is not used:
	- 'port_add' ringbuffer has no function, as 'new_ports' ringbuffer seems to be
		implemented to accomplish the same

Signed-off-by: Hanspeter Portner <dev@open-music-kontrollers.ch>