### PR TITLE
including S24_LE/BE formats to linux alsa driver

### DIFF
--- a/drivers/alsa/alsa_driver.c
+++ b/drivers/alsa/alsa_driver.c
@@ -346,20 +346,21 @@ alsa_driver_configure_stream (alsa_driver_t *driver, char *device_name,
 	unsigned int frame_rate;
 	snd_pcm_uframes_t stop_th;
 	static struct {
-		char Name[32];
+		char Name[40];
 		snd_pcm_format_t format;
 		int swapped;
 	} formats[] = {
- 	    {"32bit float little-endian", SND_PCM_FORMAT_FLOAT_LE},
+		{"32bit float little-endian", SND_PCM_FORMAT_FLOAT_LE, IS_LE},
 		{"32bit integer little-endian", SND_PCM_FORMAT_S32_LE, IS_LE},
 		{"32bit integer big-endian", SND_PCM_FORMAT_S32_BE, IS_BE},
-		{"24bit little-endian", SND_PCM_FORMAT_S24_3LE, IS_LE},
-		{"24bit big-endian", SND_PCM_FORMAT_S24_3BE, IS_BE},
+		{"24bit little-endian in 3bytes format", SND_PCM_FORMAT_S24_3LE, IS_LE},
+		{"24bit big-endian in 3bytes format", SND_PCM_FORMAT_S24_3BE, IS_BE},
+		{"24bit little-endian", SND_PCM_FORMAT_S24_LE, IS_LE},
+		{"24bit big-endian", SND_PCM_FORMAT_S24_BE, IS_BE},
 		{"16bit little-endian", SND_PCM_FORMAT_S16_LE, IS_LE},
 		{"16bit big-endian", SND_PCM_FORMAT_S16_BE, IS_BE},
 	};
 #define NUMFORMATS (sizeof(formats)/sizeof(formats[0]))
-#define FIRST_16BIT_FORMAT 5
 
 	if ((err = snd_pcm_hw_params_any (handle, hw_params)) < 0)  {
 		jack_error ("ALSA: no playback configurations available (%s)",
@@ -741,6 +742,8 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		case SND_PCM_FORMAT_S32_LE:
 		case SND_PCM_FORMAT_S24_3LE:
 		case SND_PCM_FORMAT_S24_3BE:
+		case SND_PCM_FORMAT_S24_LE:
+		case SND_PCM_FORMAT_S24_BE:
 		case SND_PCM_FORMAT_S16_LE:
 		case SND_PCM_FORMAT_S32_BE:
 		case SND_PCM_FORMAT_S16_BE:
@@ -759,6 +762,8 @@ alsa_driver_set_parameters (alsa_driver_t *driver,
 		case SND_PCM_FORMAT_S32_LE:
 		case SND_PCM_FORMAT_S24_3LE:
 		case SND_PCM_FORMAT_S24_3BE:
+		case SND_PCM_FORMAT_S24_LE:
+		case SND_PCM_FORMAT_S24_BE:
 		case SND_PCM_FORMAT_S16_LE:
 		case SND_PCM_FORMAT_S32_BE:
 		case SND_PCM_FORMAT_S16_BE:


### PR DESCRIPTION
As done in jack2 codebase, see
https://github.com/jackaudio/jack2/commit/9e70b86c6536d0177234834f2764eff5517600cc
https://github.com/jackaudio/jack2/commit/e1935e630e86766a0929fc643a4e1fb41352b4e8

I also removed the FIRST_16BIT_FORMAT macro since it was not used.
