### PR TITLE
fix garbage keys in JackPropertyChangeCallback.

### DIFF
--- a/jackd/engine.c
+++ b/jackd/engine.c
@@ -3038,6 +3038,7 @@ jack_deliver_event (jack_engine_t *engine, jack_client_internal_t *client,
                         */
                         
                         if (event->type == PropertyChange) {
+                            if (keylen) {
                                 if (write (client->event_fd, key, keylen) != keylen) {
                                         jack_error ("cannot send property change key to client [%s] (%s)",
                                                     client->control->name,
@@ -3045,6 +3046,7 @@ jack_deliver_event (jack_engine_t *engine, jack_client_internal_t *client,
                                         client->error += JACK_ERROR_WITH_SOCKETS;
                                         jack_engine_signal_problems (engine);
                                 }
+                            }
                         }
 
  			if (client->error) {

--- a/libjack/client.c
+++ b/libjack/client.c
@@ -1777,6 +1777,7 @@ jack_client_process_events (jack_client_t* client)
 		}
 
                 if (event.type == PropertyChange) {
+                    if (event.y.key_size) {
                         key = (char *) malloc (event.y.key_size);
                         if (read (client->event_fd, key, event.y.key_size) != 
                             event.y.key_size) {
@@ -1784,6 +1785,7 @@ jack_client_process_events (jack_client_t* client)
                                             strerror (errno));
                                 return -1;
                         }
+                    }
                 }
 
 		status = 0;


### PR DESCRIPTION
Issue
-----
JackPropertyChangeCallback returns a carbage key when removing all keys of
a given uuid, e.g. triggered by 'jack_remove_properties(...)'.

Expected
--------
JackPropertyChangeCallback should return a (NULL) key when removing all
keys of a given uuid.

Culprit
-------
'malloc' is called with key_size==0, which MAY NOT return a (NULL) pointer.

Fix
---
Do not call 'malloc' for key_size==0.