### PR TITLE
fix 8bit netjack MIDI payload size.

### DIFF
--- a/drivers/netjack/netjack_packet.c
+++ b/drivers/netjack/netjack_packet.c
@@ -1268,7 +1268,7 @@ render_payload_to_jack_ports_8bit (void *packet_payload, jack_nframes_t net_peri
         {
             // midi port, decode midi events
             // convert the data buffer to a standard format (uint32_t based)
-            unsigned int buffer_size_uint32 = net_period_down / 2;
+            unsigned int buffer_size_uint32 = net_period_down / 4;
             uint32_t * buffer_uint32 = (uint32_t*) packet_bufX;
             decode_midi_buffer (buffer_uint32, buffer_size_uint32, buf);
         }


### PR DESCRIPTION
MIDI payload size in 8bit netjack MIDI mode is calculated wrongly
(assumes 16bit sample size).

This bug sits at the decoding end and seems to be without concequences, as the
MIDI payload size in 8bit netjack MIDI mode at the encoding end is done
right and the decoding buffer thus cannot overflow even with a wrongly
calculated MIDI payload size.