### PR TITLE
Swap alsa_midi slave driver port-name suffixes ("out" for capture, "in" for playback)

### DIFF
--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -103,22 +103,43 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 		    const snd_seq_port_info_t * port_info_ptr, bool make_unique)
 {
 	char *c;
+	const char* const client_name = snd_seq_client_info_get_name (client_info_ptr);
+	const char* const port_name = snd_seq_port_info_get_name (port_info_ptr);
 
 	if (make_unique) {
-		snprintf (port_ptr->name,
-			  sizeof(port_ptr->name),
-			  "%s [%d] %s %s",
-			  snd_seq_client_info_get_name (client_info_ptr),
-			  snd_seq_client_info_get_client (client_info_ptr),
-			  snd_seq_port_info_get_name (port_info_ptr),
+		if (strstr (port_name, client_name) == port_name) {
+			/* entire client name is part of the port name so don't replicate it */
+			snprintf (port_ptr->name,
+			          sizeof(port_ptr->name),
+			          "[%d] %s %s",
+			          snd_seq_client_info_get_client (client_info_ptr),
+			          port_name,
 			  (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+		} else {
+			snprintf (port_ptr->name,
+			          sizeof(port_ptr->name),
+			          "%s [%d] %s %s",
+			          client_name,
+			          snd_seq_client_info_get_client (client_info_ptr),
+			          port_name,
+			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+		}
 	} else {
-		snprintf (port_ptr->name,
-			  sizeof(port_ptr->name),
-			  "%s %s %s",
-			  snd_seq_client_info_get_name (client_info_ptr),
-			  snd_seq_port_info_get_name (port_info_ptr),
-			  (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+		if (strstr (port_name, client_name) == port_name) {
+			/* entire client name is part of the port name so don't replicate it */
+			snprintf (port_ptr->name,
+			          sizeof(port_ptr->name),
+			          "%s %s",
+			          port_name,
+			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+		} else {
+			snprintf (port_ptr->name,
+			          sizeof(port_ptr->name),
+			          "%s %s %s",
+			          client_name,
+			          snd_seq_port_info_get_name (port_info_ptr),
+			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+		}
 	}
 
 	// replace all offending characters with ' '

--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -111,36 +111,32 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d:%d] %s (%s)",
+			          "[%d:%d] %s",
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          snd_seq_port_info_get_port (port_info_ptr),
-			          port_name,
-			  (dir == A2J_PORT_CAPTURE ? "out" : "in"));
+			          port_name);
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d:%d] %s %s (%s)",
+			          "[%d:%d] %s %s",
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          snd_seq_port_info_get_port (port_info_ptr),
 			          client_name,
-			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
+			          port_name);
 		}
 	} else {
 		if (strstr (port_name, client_name) == port_name) {
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s (%s)",
-			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
+			          "%s",
+			          port_name);
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s (%s)",
+			          "%s %s",
 			          client_name,
-			          snd_seq_port_info_get_name (port_info_ptr),
-			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
+			          snd_seq_port_info_get_name (port_info_ptr));
 		}
 	}
 

--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -111,32 +111,36 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d:%d] %s",
+			          "[%d:%d] %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          snd_seq_port_info_get_port (port_info_ptr),
-			          port_name);
+			          port_name,
+			  (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d:%d] %s %s",
+			          "[%d:%d] %s %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          snd_seq_port_info_get_port (port_info_ptr),
 			          client_name,
-			          port_name);
+			          port_name,
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	} else {
 		if (strstr (port_name, client_name) == port_name) {
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s",
-			          port_name);
+			          "%s (%s)",
+			          port_name,
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s",
+			          "%s %s (%s)",
 			          client_name,
-			          snd_seq_port_info_get_name (port_info_ptr));
+			          snd_seq_port_info_get_name (port_info_ptr),
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	}
 

--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -114,7 +114,7 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			          "[%d] %s %s",
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          port_name,
-			  (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			  (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
@@ -122,7 +122,7 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			          client_name,
 			          snd_seq_client_info_get_client (client_info_ptr),
 			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	} else {
 		if (strstr (port_name, client_name) == port_name) {
@@ -131,14 +131,14 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			          sizeof(port_ptr->name),
 			          "%s %s",
 			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
 			          "%s %s %s",
 			          client_name,
 			          snd_seq_port_info_get_name (port_info_ptr),
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	}
 

--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -111,16 +111,18 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d] %s %s",
+			          "[%d:%d] %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
+			          snd_seq_port_info_get_port (port_info_ptr),
 			          port_name,
 			  (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s [%d] %s %s",
-			          client_name,
+			          "[%d:%d] %s %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
+			          snd_seq_port_info_get_port (port_info_ptr),
+			          client_name,
 			          port_name,
 			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
@@ -129,13 +131,13 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s",
+			          "%s (%s)",
 			          port_name,
 			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s %s",
+			          "%s %s (%s)",
 			          client_name,
 			          snd_seq_port_info_get_name (port_info_ptr),
 			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));


### PR DESCRIPTION
Swap alsa_midi slave driver port-name suffixes:
- "out" for capture, readable/output ports (=JackPortIsOutput);
- "in" for playback, writable/input ports (=JackPortIsInput)