### PR TITLE
Update OS X CoreAudio AudioUnits API usage.

### DIFF
--- a/config/os/macosx/pThreadUtilities.h
+++ b/config/os/macosx/pThreadUtilities.h
@@ -66,7 +66,7 @@
 #define __PTHREADUTILITIES_H__
 
 #import "pthread.h"
-#import <CoreServices/../Frameworks/CarbonCore.framework/Headers/MacTypes.h>
+#import <MacTypes.h>
 
 #define THREAD_SET_PRIORITY                     0
 #define THREAD_SCHEDULED_PRIORITY               1

--- a/config/os/macosx/pThreadUtilities.h
+++ b/config/os/macosx/pThreadUtilities.h
@@ -66,7 +66,6 @@
 #define __PTHREADUTILITIES_H__
 
 #import "pthread.h"
-#import <MacTypes.h>
 
 #define THREAD_SET_PRIORITY                     0
 #define THREAD_SCHEDULED_PRIORITY               1
@@ -75,6 +74,13 @@
 #include <mach/thread_policy.h>
 #include <mach/thread_act.h>
 #include <CoreAudio/HostTime.h>
+#import <Availability.h>
+
+#if defined(MAC_OS_X_VERSION_10_7) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_7
+#import <MacTypes.h>
+#else
+#import <CoreServices/../Frameworks/CarbonCore.framework/Headers/MacTypes.h>
+#endif
 
 static inline UInt32
 _getThreadPriority (pthread_t inThread, int inWhichPriority)

--- a/drivers/coreaudio/coreaudio_driver.h
+++ b/drivers/coreaudio/coreaudio_driver.h
@@ -29,9 +29,10 @@
 #define __jack_coreaudio_driver_h__
 
 #include <CoreAudio/CoreAudio.h>
+#if !defined(MAC_OS_X_VERSION_10_6) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6
 #include <AudioToolbox/AudioConverter.h>
+#endif
 #include <AudioUnit/AudioUnit.h>
-
 #include <jack/jack.h>
 #include <jack/types.h>
 


### PR DESCRIPTION
This adds some macros to use the new API if it is supported. It also switches to use the MacTypes.h header which is already in the header path by default.