### PR TITLE
Check for clock_nanosleep before use

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,6 +285,20 @@ AC_CHECK_FUNC(clock_gettime,
 	   ])
 )
 
+AC_CHECK_FUNC(clock_nanosleep,
+       [
+           AC_DEFINE(HAVE_CLOCK_NANOSLEEP,0,"Whether or not clock_nanosleep can be found in system libraries")
+       ],
+       #
+       # if not found, check librt specifically
+       #
+       AC_CHECK_LIB(rt, clock_nanosleep,
+           [
+              AC_DEFINE(HAVE_CLOCK_NANOSLEEP,1,"Whether or not clock_nanosleep can be found in system libraries")
+	      OS_LDFLAGS="$OS_LDFLAGS -lrt"
+	   ])
+)
+
 # should we use mlockall() on this platform?
 if test "x$JACK_DO_NOT_MLOCK" = "x"; then
     AC_CHECK_HEADER(sys/mman.h,

--- a/drivers/dummy/dummy_driver.c
+++ b/drivers/dummy/dummy_driver.c
@@ -73,7 +73,7 @@ FakeVideoSync ( dummy_driver_t *driver )
 	}
 }
 
-#ifdef HAVE_CLOCK_GETTIME
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_NANOSLEEP)
 static inline unsigned long long ts_to_nsec (struct timespec ts)
 {
 	return ts.tv_sec * 1000000000LL + ts.tv_nsec;

--- a/drivers/dummy/dummy_driver.h
+++ b/drivers/dummy/dummy_driver.h
@@ -43,7 +43,7 @@ struct _dummy_driver {
 	jack_nframes_t period_size;
 	unsigned long wait_time;
 
-#ifdef HAVE_CLOCK_GETTIME
+#if defined(HAVE_CLOCK_GETTIME) && defined(HAVE_CLOCK_NANOSLEEP)
 	struct timespec next_wakeup;
 #else
 	jack_time_t next_time;


### PR DESCRIPTION
Fixes a build failure on macOS 10.12 Sierra