### PR TITLE
Fixed leaked memory with jack_tmpdir.

### DIFF
--- a/include/internal.h
+++ b/include/internal.h
@@ -509,7 +509,7 @@ extern jack_client_t *jack_client_alloc_internal(jack_client_control_t*,
 /* internal clients call this. it's defined in jack/engine.c */
 void handle_internal_client_request(jack_control_t*, jack_request_t*);
 
-extern char *jack_tmpdir;
+extern const char *jack_get_tmpdir(void);
 
 extern char *jack_user_dir(void);
 

--- a/jackd/engine.c
+++ b/jackd/engine.c
@@ -227,16 +227,22 @@ make_socket_subdirectories (const char *server_name)
 {
 	struct stat statbuf;
 	char server_dir[PATH_MAX + 1] = "";
+	const char *tmpdir = jack_get_tmpdir ();
+
+	if (tmpdir == NULL) {
+		jack_error ("Unable to get tmpdir in engine");
+		return -1;
+	}
 
 	/* check tmpdir directory */
-	if (stat (jack_tmpdir, &statbuf)) {
+	if (stat (tmpdir, &statbuf)) {
 		jack_error ("cannot stat() %s (%s)\n",
-			    jack_tmpdir, strerror (errno));
+			    tmpdir, strerror (errno));
 		return -1;
 	} else {
 		if (!S_ISDIR (statbuf.st_mode)) {
 			jack_error ("%s exists, but is not a directory!\n",
-				    jack_tmpdir);
+				    tmpdir);
 			return -1;
 		}
 	}

--- a/jackd/jackd.c
+++ b/jackd/jackd.c
@@ -812,7 +812,8 @@ main (int argc, char *argv[])
 
 		case 'l':
 			/* special flag to allow libjack to determine jackd's idea of where tmpdir is */
-			printf ("%s\n", jack_tmpdir);
+			printf("%s\n", DEFAULT_TMP_DIR);
+
 			exit (0);
 
 		case 'I':

--- a/libjack/client.c
+++ b/libjack/client.c
@@ -119,17 +119,21 @@ init_cpu ()
 
 #endif  /* USE_DYNSIMD */
 
-char *jack_tmpdir = DEFAULT_TMP_DIR;
-
-static int
+const char *
 jack_get_tmpdir ()
 {
+	static char tmpdir[PATH_MAX + 1] = "";
 	FILE* in;
 	size_t len;
 	char buf[PATH_MAX + 2]; /* allow tmpdir to live anywhere, plus newline, plus null */
 	char *pathenv;
 	char *pathcopy;
 	char *p;
+
+	/* return tmpdir if set */
+	if (tmpdir[0] != '\0') {
+		return tmpdir;
+	}
 
 	/* some implementations of popen(3) close a security loophole by
 	   resetting PATH for the exec'd command. since we *want* to
@@ -138,13 +142,13 @@ jack_get_tmpdir ()
 	 */
 
 	if ((pathenv = getenv ("PATH")) == 0) {
-		return -1;
+		return NULL;
 	}
 
 	/* don't let strtok(3) mess with the real environment variable */
 
 	if ((pathcopy = strdup (pathenv)) == NULL) {
-		return -1;
+		return NULL;
 	}
 	p = strtok (pathcopy, ":");
 
@@ -169,13 +173,13 @@ jack_get_tmpdir ()
 	if (p == NULL) {
 		/* no command successfully started */
 		free (pathcopy);
-		return -1;
+		return NULL;
 	}
 
 	if (fgets (buf, sizeof(buf), in) == NULL) {
 		pclose (in);
 		free (pathcopy);
-		return -1;
+		return NULL;
 	}
 
 	len = strlen (buf);
@@ -184,21 +188,16 @@ jack_get_tmpdir ()
 		/* didn't get a whole line */
 		pclose (in);
 		free (pathcopy);
-		return -1;
+		return NULL;
 	}
 
-	if ((jack_tmpdir = (char*)malloc (len)) == NULL) {
-		free (pathcopy);
-		return -1;
-	}
-
-	memcpy (jack_tmpdir, buf, len - 1);
-	jack_tmpdir[len - 1] = '\0';
+	memcpy (tmpdir, buf, len - 1);
+	tmpdir[len - 1] = '\0';
 
 	pclose (in);
 	free (pathcopy);
 
-	return 0;
+	return tmpdir;
 }
 
 void
@@ -1260,7 +1259,7 @@ jack_client_open_aux (const char *client_name,
 	/* External clients need to know where the tmpdir used for
 	   communication with the server lives
 	 */
-	if (jack_get_tmpdir ()) {
+	if (jack_get_tmpdir () == NULL) {
 		*status |= JackFailure;
 		jack_messagebuffer_exit ();
 		return NULL;
@@ -1458,15 +1457,24 @@ char *
 jack_user_dir (void)
 {
 	static char user_dir[PATH_MAX + 1] = "";
+	const char *tmpdir;
 
 	/* format the path name on the first call */
 	if (user_dir[0] == '\0') {
+		tmpdir = jack_get_tmpdir ();
+
+		/* previous behavior of jack_tmpdir, should be changed later */
+		if (tmpdir == NULL) {
+			jack_error ("Unable to get tmpdir in user dir");
+			tmpdir = DEFAULT_TMP_DIR;
+		}
+
 		if (getenv ("JACK_PROMISCUOUS_SERVER")) {
 			snprintf (user_dir, sizeof(user_dir), "%s/jack",
-				  jack_tmpdir);
+				  tmpdir);
 		} else {
 			snprintf (user_dir, sizeof(user_dir), "%s/jack-%d",
-				  jack_tmpdir, getuid ());
+				  tmpdir, getuid ());
 		}
 	}
 


### PR DESCRIPTION
When new clients are created and jack_get_tmpdir() is called, jack_tmpdir is
not free'd resulting in memory being leaked since it is set to a new
value from malloc and unable to be free'd later. This means that if you
are writing a program that creates and deletes clients regularly there
will be a serious memory issue. Also, even when all clients are closed, the malloc'd
jack_tmpdir is not free'd which makes it impossible to free all
allocated memory by the end of a program's execution making detecting
real memory leaks a bit more difficult. This commit fixes this by
keeping track of how many clients there are and acting on memory based
off such. Basically with this and VALGRIND_MEMSET defined, valgrind will
no longer complain! 😄