### PR TITLE
Do not override libdir on configure for 64-bit OS'es

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 dnl $Id$
 
-AC_INIT([jack-audio-connection-kit],[0.125.0rc1],
+AC_INIT([jack-audio-connection-kit],[0.125.1],
                 [jack-devel@lists.jackaudio.org],[],[http://www.jackaudio.org/])
 
 AC_CONFIG_SRCDIR([jackd/jackd.c])
@@ -195,27 +195,6 @@ AC_SUBST(OS_LDFLAGS)
 AC_SUBST(USE_MD5SUM)
 AC_DEFINE_UNQUOTED(USE_MD5SUM,"$USE_MD5SUM",[Using md5sum command line if available])
 AM_CONDITIONAL(USE_MD5SUM, $USE_MD5SUM)
-
-#
-# We need to establish suitable defaults for a 64-bit OS
-libnn=lib
-case "${host_os}" in
-    linux*)
-    case "${host_cpu}" in
-	x86_64|mips64|ppc64|sparc64|s390x)
-        libnn=lib64
-	;;
-    esac
-    ;;
-    solaris*)
-    ## libnn=lib/sparcv9 ## on 64-bit only, but that's compiler-specific
-    ;;
-esac
-
-## take care not to  override the command-line setting
-if test "${libdir}" = '${exec_prefix}/lib'; then
-  libdir='${exec_prefix}/'${libnn}
-fi
 
 # system-dependent config.h values
 test "x$JACK_THREAD_STACK_TOUCH" = "x" && JACK_THREAD_STACK_TOUCH=500000

--- a/drivers/alsa_midi/port.c
+++ b/drivers/alsa_midi/port.c
@@ -111,34 +111,36 @@ a2j_port_fill_name (struct a2j_port * port_ptr, int dir, snd_seq_client_info_t *
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "[%d] %s %s",
+			          "[%d:%d] %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
+			          snd_seq_port_info_get_port (port_info_ptr),
 			          port_name,
-			  (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			  (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s [%d] %s %s",
-			          client_name,
+			          "[%d:%d] %s %s (%s)",
 			          snd_seq_client_info_get_client (client_info_ptr),
+			          snd_seq_port_info_get_port (port_info_ptr),
+			          client_name,
 			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	} else {
 		if (strstr (port_name, client_name) == port_name) {
 			/* entire client name is part of the port name so don't replicate it */
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s",
+			          "%s (%s)",
 			          port_name,
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		} else {
 			snprintf (port_ptr->name,
 			          sizeof(port_ptr->name),
-			          "%s %s %s",
+			          "%s %s (%s)",
 			          client_name,
 			          snd_seq_port_info_get_name (port_info_ptr),
-			          (dir == A2J_PORT_CAPTURE ? "in" : "out"));
+			          (dir == A2J_PORT_CAPTURE ? "out" : "in"));
 		}
 	}
 


### PR DESCRIPTION
Drop the libdir override in configure on 64-bit OS'es.

Forcing configure --libdir=${exec_prefix}/lib64 is no more a viable default on 64bit target build architectures, especially on arch-independent builds, on some Debian based GNU/Linux distros.

Also bumps version to 0.125.1.