### PR TITLE
Use LC_ALL=C to generate manpage date

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,5 @@
 .0.1:
-	@[ -z "$$SOURCE_DATE_EPOCH" ] || d=--date=@$$SOURCE_DATE_EPOCH ; sed -e "s/!VERSION!/@JACK_RELEASE@/g" -e "s/!DATE!/`date $$d '+%B %Y'`/g" < $*.0 > $@
+	@[ -z "$$SOURCE_DATE_EPOCH" ] || d=--date=@$$SOURCE_DATE_EPOCH ; sed -e "s/!VERSION!/@JACK_RELEASE@/g" -e "s/!DATE!/`LC_ALL=C date $$d '+%B %Y'`/g" < $*.0 > $@
 	@echo Built $*.1 from template
 
 manpages = $(patsubst %.0,%.1,$(wildcard *.0))


### PR DESCRIPTION
Without this, the user's locale may influence the content of the manpages (eg juin instead of June for a french locale).