### PR TITLE
Using the process realtime priority instead of the thread realtime priority when sufficient.

### DIFF
--- a/libjack/thread.c
+++ b/libjack/thread.c
@@ -300,8 +300,9 @@ jack_drop_real_time_scheduling (pthread_t thread)
 			    strerror (errno));
 		return -1;
 	}
-	if (policy == SCHED_OTHER)
+	if (policy == SCHED_OTHER) {
 		return 0; // already
+	}
 
 	memset (&rtparam, 0, sizeof(rtparam));
 
@@ -320,8 +321,9 @@ jack_acquire_real_time_scheduling (pthread_t thread, int priority)
 	struct sched_param rtparam;
 	int x;
 
-	if (jack_process_already_has_real_time_scheduling (priority) != 0)
+	if (jack_process_already_has_real_time_scheduling (priority) != 0) {
 		return 0;
+	}
 
 	memset (&rtparam, 0, sizeof(rtparam));
 	rtparam.sched_priority = priority;


### PR DESCRIPTION
So far only on FreeBSD. This needs to be extended to Linux as well.

There is no need to change the thread priority when this isn't actually needed.