### PR TITLE
configure: update -mmacosx-version-min= to 10.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -330,8 +330,9 @@ AC_ARG_ENABLE(ancient_libc,
 JACK_CORE_CFLAGS="$JACK_CORE_CFLAGS $JACK_LIBC_HELPER_FLAGS"
 
 case $build_os in
-     # we need weak linkage which appeared in 10.2, but lets ask for 10.4 anyway
-     darwin*) JACK_CORE_CFLAGS="$JACK_CORE_CFLAGS -mmacosx-version-min=10.4" ;;
+     # we need weak linkage which appeared in 10.2, but for compatibility with
+     # macOS 10.14 and above we cannot set a minimum version below 10.6 here.
+     darwin*) JACK_CORE_CFLAGS="$JACK_CORE_CFLAGS -mmacosx-version-min=10.6" ;;
 esac
 
 AC_ARG_WITH(cpu-target,


### PR DESCRIPTION
This could be done other ways if it turns out there's a flood of people out there desperate for 10.4 or 10.5 compatibility, but I expect this is safe enough to solve in the simplest possible way, which is by just bumping the number here to 10.6.

Fixes https://github.com/jackaudio/jack1/issues/81.