### PR TITLE
Force 16-byte buffer alignment for SIMD

### DIFF
--- a/libjack/port.c
+++ b/libjack/port.c
@@ -630,13 +630,22 @@ jack_port_get_buffer (jack_port_t *port, jack_nframes_t nframes)
 size_t
 jack_port_type_buffer_size (jack_port_type_info_t* port_type_info, jack_nframes_t nframes)
 {
+	size_t size;
+
 	if ( port_type_info->buffer_scale_factor < 0 ) {
 		return port_type_info->buffer_size;
 	}
 
-	return port_type_info->buffer_scale_factor
+	size = port_type_info->buffer_scale_factor
 	       * sizeof(jack_default_audio_sample_t)
 	       * nframes;
+
+#ifdef USE_DYNSIMD
+	/* Round up to the next multiple of 16 bytes, align buffers for SIMD. */
+	size = (size + 15) & (~ (size_t)0x0f);
+#endif  /* USE_DYNSIMD */
+
+	return size;
 }
 
 int


### PR DESCRIPTION
Hello,

I stumbled upon this when I investigated jackd consistently crashing in some
configurations of OSS on FreeBSD. In summary, the buffer size is reset
according to the number of samples requested by the driver backend. If this
number is not a multiple of 4, jackd will misalign its buffers for SSE SIMD
instructions and die with SIGBUS when processing them. The proposed fix
introduces some padding to align the buffers, in case this happens.

Please note that even though these odd buffer sizes seem to be unusual, the
problem is not necessarily tied to the OSS backend.

More details can be found in the commit message and in the original bug report:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234574
The proposed patch is the same as currently applied in the FreeBSD ports tree.

Thanks for your consideration

Florian Walpen

-------------------------------------------------------------------------------

_Commit message:_
With build option USE_DYNSIMD, SSE SIMD instructions are enabled that require
16-byte aligned buffer data. Multiple buffers are allocated in one contiguous
block of memory, the buffer size is determined by the number of 4-byte float
samples (nframes) per buffer. If this number is not set to a multiple of 4, the
offset of subsequent buffers will be misaligned and jackd crashes with SIGBUS.

An example of this actually happening would be using 24 bit sample size in the
OSS backend, where the page sized system buffers may result in an odd number of
samples per buffer. See
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=234574
for a detailed bug report.

This change effectively adds some padding by rounding up the allocated buffer
size to a multiple of 16 bytes, given that both:

a) SIMD instructions are enabled in the build.
b) The requested buffer size is not already a multiple of 16 bytes.

All other cases should be unaffected. The existing buffer handling, copy and
mix code seems to be well prepared for padded buffers, with the number of
samples (nframes) and buffer offsets kept separately.