### PR TITLE
(Re-)Enable search engine for API docs

### DIFF
--- a/doc/reference.doxygen.in
+++ b/doc/reference.doxygen.in
@@ -1369,7 +1369,7 @@ DOT_CLEANUP            = YES
 # The SEARCHENGINE tag specifies whether or not a search engine should be 
 # used. If set to NO the values of all tags below this one will be ignored.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 # newer stuff
 HTML_DYNAMIC_MENUS     = NO


### PR DESCRIPTION
This was enabled on https://jackaudio.org/api/ before, but changed when the API docs were updated a while ago, after they hadn't been updated for years.