### PR TITLE
Install systemdeps header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,19 +33,19 @@ dist-hook: dist-check-doxygen
 libjackincludedir = $(includedir)/jack
 
 libjackinclude_HEADERS =   \
+	jack/control.h     \
 	jack/intclient.h   \
 	jack/jack.h        \
+	jack/jslist.h      \
+	jack/metadata.h    \
+	jack/midiport.h    \
 	jack/ringbuffer.h  \
-	jack/statistics.h  \
 	jack/session.h     \
+	jack/statistics.h  \
+	jack/systemdeps.h  \
 	jack/thread.h      \
 	jack/transport.h   \
 	jack/types.h       \
-	jack/midiport.h    \
-	jack/weakmacros.h  \
+	jack/uuid.h        \
 	jack/weakjack.h    \
-	jack/control.h     \
-	jack/metadata.h     \
-	jack/uuid.h     \
-	jack/jslist.h
-
+	jack/weakmacros.h

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -7,16 +7,22 @@ DOX=reference.doxygen
 DOXSOURCES=mainpage.dox transport.dox porting.dox fsm.png fsm.eps \
 	../example-clients/inprocess.c \
 	../example-clients/simple_client.c \
+	../jack/control.h \
 	../jack/intclient.h \
 	../jack/jack.h \
+	../jack/jslist.h \
+	../jack/metadata.h \
+	../jack/midiport.h \
 	../jack/ringbuffer.h \
+	../jack/session.h \
+	../jack/statistics.h \
+	../jack/systemdeps.h \
 	../jack/thread.h \
 	../jack/transport.h \
 	../jack/types.h \
-	../jack/midiport.h \
-	../jack/session.h \
+	../jack/uuid.h \
 	../jack/weakjack.h \
-	../jack/control.h
+	../jack/weakmacros.h
 
 EXTRA_DIST=mainpage.dox transport.dox fsm.png fsm.eps porting.dox
 

--- a/doc/reference.doxygen.in
+++ b/doc/reference.doxygen.in
@@ -518,18 +518,22 @@ INPUT                  = @top_srcdir@/doc/mainpage.dox \
                          @top_srcdir@/doc/porting.dox \
                          @top_srcdir@/example-clients/inprocess.c \
                          @top_srcdir@/example-clients/simple_client.c \
+                         @top_srcdir@/jack/control.h \
                          @top_srcdir@/jack/intclient.h \
                          @top_srcdir@/jack/jack.h \
+                         @top_srcdir@/jack/jslist.h \
+                         @top_srcdir@/jack/metadata.h \
+                         @top_srcdir@/jack/midiport.h \
                          @top_srcdir@/jack/ringbuffer.h \
+                         @top_srcdir@/jack/session.h \
                          @top_srcdir@/jack/statistics.h \
+                         @top_srcdir@/jack/systemdeps.h \
                          @top_srcdir@/jack/thread.h \
                          @top_srcdir@/jack/transport.h \
                          @top_srcdir@/jack/types.h \
-                         @top_srcdir@/jack/midiport.h \
-                         @top_srcdir@/jack/session.h \
+                         @top_srcdir@/jack/uuid.h \
                          @top_srcdir@/jack/weakjack.h \
-                         @top_srcdir@/jack/control.h \
-                         @top_srcdir@/jack/metadata.h \
+                         @top_srcdir@/jack/weakmacros.h \
 
 # This tag can be used to specify the character encoding of the source files 
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is 


### PR DESCRIPTION
As the headers have been updated in #110, we also need to make sure to install the "new" systemdeps.h header file.

This pull request also does some alphabetical sorting and adds any missing headers to the library and documentation install targets.

Relates to #108 