### PR TITLE
CI automated tarball creation and deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Archive: ignore dotfiles
+.* export-ignore
+.*/** export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Release tarball archive
+on:
+  push:
+    tags:
+    - '[0-9]*'
+jobs:
+  archive_source_code:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Source Code Tarball
+    runs-on: ubuntu-18.04
+    env:
+      ARCHIVE_BASENAME: jack1-${{ github.ref_name }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Dependencies setup
+      run: |
+        sudo apt-get update
+        sudo apt-get install python-pip
+        sudo pip install git-archive-all
+    - name: Archive source code
+      shell: bash
+      run: |
+        cd "${GITHUB_WORKSPACE}"
+        git-archive-all --prefix="${ARCHIVE_BASENAME}/" -9 "${{runner.workspace}}/${ARCHIVE_BASENAME}.tar.gz"
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Source code tarball
+        path: ${{runner.workspace}}/${{env.ARCHIVE_BASENAME}}.tar.gz
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-18.04
+    needs:
+    - archive_source_code
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: Source code tarball
+    - uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      with:
+        tag_name: ${{ github.ref_name }}
+        name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: false
+        files: |
+          jack1-${{ github.ref_name }}.*


### PR DESCRIPTION
Automate the creation of the source tarball using `git-archive-all`, including submodules (recursively). It also excludes dotfiles, which are only used by past and present VCS, so let me know if this is undesirable.
It works only when tagging and deploys the resulting file to GH Releases, so the only manual action required for the process is to create a new tag.
The result can be seen as preview [here](https://github.com/redtide/jack1/releases/tag/0.125.1).